### PR TITLE
Allow users to specify project name in pom

### DIFF
--- a/src/main/scala/com/typesafe/sbt/pom/MavenProjectHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/pom/MavenProjectHelper.scala
@@ -111,8 +111,9 @@ object MavenProjectHelper {
   
   // TODO - Can we  pick a better name and does this need scrubbed?
   def makeProjectName(pom: PomModel, overrideName: Option[String]): String = {
-    val directoryName = overrideName.getOrElse(pom.getPomFile.getParentFile.getName)
-    directoryName
+    val pomName = Option(pom.getProperties.get("sbt.project.name").asInstanceOf[String])
+    val directoryName = pom.getPomFile.getParentFile.getName
+    overrideName.getOrElse(pomName.getOrElse(directoryName))
   }
     
   def makeProjectTree(pomFile: File): ProjectTree = {


### PR DESCRIPTION
The approach of guessing the directory name doesn't work so well for us in Spark because we have a fairly complicated nested set of projects.

This proposal allows the user to add a Maven property `sbt.project.name` which overrides the directory name.
