### PR TITLE
Remove binary version suffix from subproject's name whenever needed.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/pom/MavenHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/pom/MavenHelper.scala
@@ -47,9 +47,15 @@ object MavenHelper {
     finally out.close()
     out.getBuffer.toString
   }
-  
+  val ExtractIdRegex = """(.*)_2.\d+.*""".r
+  def removeBinaryVersionSuffix(v: String): String = v match {
+    case ExtractIdRegex(a) => a
+    case _ => v
+  }
+
   def pullSettingsFromPom: Seq[Setting[_]] = Seq(
-    name <<= fromPom(_.getArtifactId),
+    /* Often poms have artifactId with binary version suffix. This should ideally be removed. */
+    name <<= fromPom(x => removeBinaryVersionSuffix(x.getArtifactId)),
     organization <<= fromPom(_.getGroupId),
     version <<= fromPom(_.getVersion),
     // TODO - Add configuration on whether we force the scalaVersion to exist...


### PR DESCRIPTION
Often in pom files artifact ids are appended with binary version, since
maven does not natively support scala style of publishing artifact with binary suffix.
This patch takes care of applying scrub whenever needed.
