### PR TITLE
sbt 1.x support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,4 @@ initialCommands in console :=
      |""".stripMargin
 
 
-scriptedSettings
-
-scriptedLaunchOpts += { "-Dproject.version=" + version.value }
-
+scriptedLaunchOpts := scriptedLaunchOpts.value ++ Seq("-Dproject.version=" + version.value)

--- a/notes/release-process.markdown
+++ b/notes/release-process.markdown
@@ -5,7 +5,7 @@
 1. Create a branch to do the release work on. Something like `release-<X>.<Y>.<Z>` is good.
 2. Write release notes in Markdown with filename  `notes/<X>.<Y>.markdown`. Go through the commit logs and collect the major new features, bug fixes, deprecations, and anything else relevant to users. Making note of breaking changes is particularly important.
 5. Run `git tag -u <GPG key id> v<X>.<Y>.<Z> && git push`. This creates the tag that the `sbt-git` plugin will use to extract the artifact version number and publishes it. Providing a GPG key is just good form. [Here's some documention](http://www.dewinter.com/gnupg_howto/english/GPGMiniHowto-3.html) on how to get set up to have one.
-6. Run `sbt scripted publish`. Executes the tests first and then stages the binary in Bintray. [See SBT documentation](http://www.scala-sbt.org/0.13/docs/Bintray-For-Plugins.html) on how to get set up with Bintray. 
+6. Run `sbt scripted publish`. Executes the tests first and then stages the binary in Bintray. [See SBT documentation](http://www.scala-sbt.org/1.0/docs/Bintray-For-Plugins.html) on how to get set up with Bintray.
 7. Confirm the plugin is properly staged for release on Bintray.  The Bintray page for `sbt-pom-reader` is [here](https://bintray.com/sbt/sbt-plugin-releases/sbt-pom-reader/view).
 8. Run `sbt bintrayRelease`. This moves the plugin from the staged release to published release on Bintray.
 9. Update `git.baseVersion` to next release.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
 libraryDependencies += {
-  "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,9 +5,9 @@ resolvers += Resolver.url(
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
 libraryDependencies += {
   "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/com/typesafe/sbt/pom/MavenHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/pom/MavenHelper.scala
@@ -9,7 +9,6 @@ import org.apache.maven.model.{
   Repository => PomRepository
 }
 import org.apache.maven.settings.{Settings ⇒ MavenSettings}
-import Project.Initialize
 import SbtPomKeys._
 import collection.JavaConverters._
 import MavenUserSettingsHelper._

--- a/src/main/scala/com/typesafe/sbt/pom/MavenProjectHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/pom/MavenProjectHelper.scala
@@ -8,7 +8,6 @@ import org.apache.maven.model.{
   Dependency => PomDependency,
   Repository => PomRepository
 }
-import Project.Initialize
 import SbtPomKeys._
 import collection.JavaConverters._
 

--- a/src/main/scala/com/typesafe/sbt/pom/MavenUserSettingsHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/pom/MavenUserSettingsHelper.scala
@@ -5,7 +5,6 @@ import org.apache.maven.settings.building.{DefaultSettingsBuilderFactory, Defaul
 import org.apache.maven.settings.{Settings ⇒ MavenSettings}
 import sbt._
 
-import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 /** Helper object with functions to extract settings from the user's
@@ -30,16 +29,16 @@ object MavenUserSettingsHelper {
   def getUserResolvers(settings: MavenSettings): Seq[Resolver] = {
     val profiles = settings.getProfilesAsMap
     for {
-      profileName ← settings.getActiveProfiles
+      profileName ← settings.getActiveProfiles.asScala
       profile ← Option(profiles.get(profileName)).toSeq
-      repo ← profile.getRepositories
+      repo ← profile.getRepositories.asScala
     } yield repo.getId at repo.getUrl
   }
 
   /** Extract the server credentials from the given settings file. */
   def serverCredentials(settings: MavenSettings): Seq[ServerCredentials] = {
     for {
-      s ← settings.getServers
+      s ← settings.getServers.asScala
     } yield ServerCredentials(s.getId, s.getUsername, s.getPassword)
   }
 

--- a/src/main/scala/com/typesafe/sbt/pom/PomBuild.scala
+++ b/src/main/scala/com/typesafe/sbt/pom/PomBuild.scala
@@ -1,11 +1,12 @@
 package com.typesafe.sbt.pom
 
 import sbt._
+import sbt.internal.BuildDef
 
 /** A helper class that allows us to load all maven reactor projects
  *  upon boot.
  */
-trait PomBuild extends Build {
+trait PomBuild extends BuildDef {
   val profiles: Seq[String] = Seq()
 
   /** These can be used to override properties in maven pom */


### PR DESCRIPTION
There didn't seem to be many changes needed to get this up and running with sbt 1.x, and I've been able to use it locally without any issues.

I'm still new to sbt plugin development, so there may be some considerations here that I'm not aware of yet. In particular, I found:
- [sbt-compat](https://github.com/dwijnand/sbt-compat) which seems to only be for easing the transition to the new structure
- [sbt-1.x-plugin-migration](https://github.com/sbt/sbt/wiki/sbt-1.x-plugin-migration) which seems to be tracking plugins that have successfully upgraded to sbt 1.x
- [Cross Build Plugins](http://www.scala-sbt.org/1.0/docs/Cross-Build-Plugins.html) from the official docs, but I don't know how to set that up in a safe way that won't confuse the build process.

If you've got some pointers, I'd appreciate them -- I wouldn't want to leave 0.13 hamstrung by this upgrade