### PR TITLE
Attempt to fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+dist: trusty
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+jdk: openjdk6
 language: scala
 scala:
-   - 2.10.4
-jdk:
-   - openjdk6
+   - 2.10.6
    
 # Fix OpenJDK builds
 # https://github.com/travis-ci/travis-ci/issues/5227

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
-dist: trusty
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-jdk: openjdk6
 language: scala
 scala:
-   - 2.10.6
+   - 2.10.7
+jdk:
+   - openjdk8
    
 # Fix OpenJDK builds
 # https://github.com/travis-ci/travis-ci/issues/5227


### PR DESCRIPTION
Binds Trusty distro version.
Obtains OpenJDK 6 according to Travis rules.