### PR TITLE
Respect settings.xml mirror repository definition

### DIFF
--- a/src/main/scala/sbtpomreader/MavenHelper.scala
+++ b/src/main/scala/sbtpomreader/MavenHelper.scala
@@ -34,7 +34,8 @@ object MavenHelper {
       pomLocation.value,
       mvnLocalRepository.value,
       profiles.value,
-      mavenUserProperties.value
+      mavenUserProperties.value,
+      settingsLocation.value
     ),
     effectiveSettings := loadUserSettings(settingsLocation.value, profiles.value),
     showEffectivePom := showPom(pomLocation.value, effectivePom.value, streams.value),

--- a/src/main/scala/sbtpomreader/MavenPomResolver.scala
+++ b/src/main/scala/sbtpomreader/MavenPomResolver.scala
@@ -20,23 +20,22 @@ object MavenPomResolver {
   val system = newRepositorySystemImpl
   require(system != null, "Repository system failed to initialize")
 
-  private[sbtpomreader] lazy val mirrorSelector: Option[MirrorSelector] = {
-    val settingsFile = new File(
-      sys.props("user.home") + File.separator + ".m2" + File.separator + "settings.xml"
-    )
+  private[sbtpomreader] def mirrorSelector(settingsFile: File): Option[MirrorSelector] = {
     MavenUserSettingsHelper.loadUserSettings(settingsFile, Seq.empty).flatMap { settings =>
       val selector = MavenUserSettingsHelper.buildMirrorSelector(settings)
       if (settings.getMirrors.isEmpty) None else Some(selector)
     }
   }
 
-  def apply(localRepo: File) = new MavenPomResolver(system, localRepo)
+  def apply(localRepo: File, settingsFile: File) = new MavenPomResolver(system, localRepo, settingsFile)
 }
 
-class MavenPomResolver(system: RepositorySystem, localRepo: File) {
+class MavenPomResolver(system: RepositorySystem, localRepo: File, settingsFile: File) {
+  private val mirrors = MavenPomResolver.mirrorSelector(settingsFile)
+
   val session = {
     val s = newSessionImpl(system, localRepo)
-    MavenPomResolver.mirrorSelector.foreach(s.setMirrorSelector)
+    mirrors.foreach(s.setMirrorSelector)
     s
   }
 
@@ -46,7 +45,7 @@ class MavenPomResolver(system: RepositorySystem, localRepo: File) {
     val central = new RemoteRepository.Builder(
       "central", "default", "https://repo.maven.apache.org/maven2"
     ).build()
-    MavenPomResolver.mirrorSelector match {
+    mirrors match {
       case Some(selector) =>
         Seq(Option(selector.getMirror(central)).getOrElse(central))
       case None =>

--- a/src/main/scala/sbtpomreader/MavenPomResolver.scala
+++ b/src/main/scala/sbtpomreader/MavenPomResolver.scala
@@ -14,23 +14,45 @@ import org.apache.maven.model.building.{
 }
 import org.apache.maven.model.resolution.ModelResolver
 import org.eclipse.aether.RepositorySystem
-import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.repository.{ MirrorSelector, RemoteRepository }
 
 object MavenPomResolver {
   val system = newRepositorySystemImpl
   require(system != null, "Repository system failed to initialize")
+
+  private[sbtpomreader] lazy val mirrorSelector: Option[MirrorSelector] = {
+    val settingsFile = new File(
+      sys.props("user.home") + File.separator + ".m2" + File.separator + "settings.xml"
+    )
+    MavenUserSettingsHelper.loadUserSettings(settingsFile, Seq.empty).flatMap { settings =>
+      val selector = MavenUserSettingsHelper.buildMirrorSelector(settings)
+      if (settings.getMirrors.isEmpty) None else Some(selector)
+    }
+  }
+
   def apply(localRepo: File) = new MavenPomResolver(system, localRepo)
 }
 
 class MavenPomResolver(system: RepositorySystem, localRepo: File) {
-  val session = newSessionImpl(system, localRepo)
+  val session = {
+    val s = newSessionImpl(system, localRepo)
+    MavenPomResolver.mirrorSelector.foreach(s.setMirrorSelector)
+    s
+  }
 
   private val modelBuilder = (new DefaultModelBuilderFactory).newInstance
 
-  private val defaultRepositories: Seq[RemoteRepository] =
-    Seq(
-      new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2").build()
-    )
+  private val defaultRepositories: Seq[RemoteRepository] = {
+    val central = new RemoteRepository.Builder(
+      "central", "default", "https://repo.maven.apache.org/maven2"
+    ).build()
+    MavenPomResolver.mirrorSelector match {
+      case Some(selector) =>
+        Seq(Option(selector.getMirror(central)).getOrElse(central))
+      case None =>
+        Seq(central)
+    }
+  }
 
   // TODO - Add repositories from the pom...
   val modelResolver: ModelResolver = {

--- a/src/main/scala/sbtpomreader/MavenUserSettingsHelper.scala
+++ b/src/main/scala/sbtpomreader/MavenUserSettingsHelper.scala
@@ -7,6 +7,8 @@ import scala.collection.JavaConverters._
 import org.apache.maven.model.{ Model => PomModel, Repository => PomRepository }
 import org.apache.maven.settings.{ Settings => MavenSettings }
 import org.apache.maven.settings.building.{ DefaultSettingsBuilderFactory, DefaultSettingsBuildingRequest }
+import org.eclipse.aether.repository.MirrorSelector
+import org.eclipse.aether.util.repository.DefaultMirrorSelector
 
 /**
  * Helper object with functions to extract settings from the user's Maven settings file (typically ~/.m2/settings.xml)
@@ -43,6 +45,27 @@ object MavenUserSettingsHelper {
     for {
       s <- settings.getServers.asScala
     } yield ServerCredentials(s.getId, s.getUsername, s.getPassword)
+
+  /**
+   * Build a MirrorSelector from the mirrors defined in Maven settings.
+   * The returned selector applies the same mirror matching rules as Maven itself
+   * (supporting `*`, `central`, `external:*`, negations like `*,!repo1`, etc.).
+   */
+  def buildMirrorSelector(settings: MavenSettings): MirrorSelector = {
+    val selector = new DefaultMirrorSelector()
+    for (mirror <- settings.getMirrors.asScala) {
+      selector.add(
+        mirror.getId,
+        mirror.getUrl,
+        Option(mirror.getLayout).getOrElse("default"),
+        false,
+        mirror.isBlocked,
+        mirror.getMirrorOf,
+        mirror.getMirrorOfLayouts
+      )
+    }
+    selector
+  }
 
   /** Associates server credentials defined in the settings with repositories referenced in the POM. */
   // TODO - Grab authentication realm...

--- a/src/main/scala/sbtpomreader/package.scala
+++ b/src/main/scala/sbtpomreader/package.scala
@@ -26,7 +26,8 @@ package object sbtpomreader {
       pom: File,
       localRepo: File = defaultLocalRepo,
       profiles: Seq[String],
-      userProps: Map[String, String]
+      userProps: Map[String, String],
+      settingsFile: File = new File(sys.props("user.home"), ".m2/settings.xml")
   ) =
-    MavenPomResolver(localRepo).loadEffectivePom(pom, Seq.empty, profiles, userProps)
+    MavenPomResolver(localRepo, settingsFile).loadEffectivePom(pom, Seq.empty, profiles, userProps)
 }

--- a/src/sbt-test/simple-pom/can-read-settings-mirrors/build.sbt
+++ b/src/sbt-test/simple-pom/can-read-settings-mirrors/build.sbt
@@ -1,0 +1,13 @@
+
+settingsLocation := baseDirectory.value / "override-settings.xml"
+
+TaskKey[Unit]("checkMirrors") := {
+  val settings = effectiveSettings.value
+  assert(settings.isDefined, "Expected effective settings to be defined")
+  val mirrors = settings.get.getMirrors
+  assert(mirrors.size == 1, s"Expected 1 mirror, got ${mirrors.size}")
+  val mirror = mirrors.get(0)
+  assert(mirror.getId == "my-mirror", s"Expected mirror id 'my-mirror', got '${mirror.getId}'")
+  assert(mirror.getMirrorOf == "central", s"Expected mirrorOf 'central', got '${mirror.getMirrorOf}'")
+  assert(mirror.getUrl == "https://mirror.example.com/maven2", s"Expected mirror url 'https://mirror.example.com/maven2', got '${mirror.getUrl}'")
+}

--- a/src/sbt-test/simple-pom/can-read-settings-mirrors/override-settings.xml
+++ b/src/sbt-test/simple-pom/can-read-settings-mirrors/override-settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>my-mirror</id>
+            <mirrorOf>central</mirrorOf>
+            <url>https://mirror.example.com/maven2</url>
+        </mirror>
+    </mirrors>
+</settings>

--- a/src/sbt-test/simple-pom/can-read-settings-mirrors/pom.xml
+++ b/src/sbt-test/simple-pom/can-read-settings-mirrors/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.jsuereth.junk</groupId>
+  <artifactId>test-project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <scala.version>2.13.13</scala.version>
+    <encoding>UTF-8</encoding>
+    <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <scalaVersion>${scala.version}</scalaVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/sbt-test/simple-pom/can-read-settings-mirrors/project/plugin.sbt
+++ b/src/sbt-test/simple-pom/can-read-settings-mirrors/project/plugin.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-pom-reader" % sys.props("project.version"))

--- a/src/sbt-test/simple-pom/can-read-settings-mirrors/test
+++ b/src/sbt-test/simple-pom/can-read-settings-mirrors/test
@@ -1,0 +1,1 @@
+> checkMirrors


### PR DESCRIPTION
Noticed this in the Spark build. Internally we are using a maven mirror that we'd like to keep as a user setting, instead of adding it to code. Seems like other settings in settings.xml are picked up, so picking up any defined mirrors seems in line with the general approach.